### PR TITLE
Litera style

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -8,13 +8,6 @@
 app_ui <- function(request) {
   tagList(# Leave this function for adding external resources
     golem_add_external_resources(),
-    shiny::tags$head(
-      tags$link(
-        rel = "stylesheet",
-        type = "text/css",
-        href = "litera_style.css"
-      )
-    ),
     # Your application UI logic
     fluidPage(
       shiny::navbarPage(

--- a/inst/app/www/litera_style.css
+++ b/inst/app/www/litera_style.css
@@ -13,6 +13,6 @@
 }
 
 
-.h1, .h2, .h3, .h4, .h5, .h6 {
+h1, h2, h3, h4, h5, h6 {
   font-family: "Josefin Sans" !important;
 }


### PR DESCRIPTION
The changes here ensure that the "litera_style.css" file is applied to the app.

In the original version of the .css file, "Josefin sans" was applied to elements of class "h1", "h2" and so on. Here, we change it so that all heading elements (with tag "h1", "h2", ...)  have this font applied.

A little bit of clean up was added as well:

The previous version added an explicit stylesheet for "litera_style.css" to the HTML head. But golem's `golem_add_external_resources` makes `(inst)/app/www/the_file` available as "www/the_file" in the browser. automatically.

So the href should have been "www/litera_style.css" in tags$link, but the link wasn't needed.